### PR TITLE
Merge Protection Levels

### DIFF
--- a/UPTEthereumSigner.xcodeproj/project.pbxproj
+++ b/UPTEthereumSigner.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		59A986F3024745274B230644 /* Pods-UPTEthereumSigner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UPTEthereumSigner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UPTEthereumSigner/Pods-UPTEthereumSigner.debug.xcconfig"; sourceTree = "<group>"; };
 		5D81C0305A79098E2D3A8A94 /* Pods_UPTEthereumSigner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UPTEthereumSigner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		803379E1C20F6073CAC656C7 /* Pods_UPTEthereumSignerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UPTEthereumSignerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE018FA420EF1C460009CD36 /* UPTProtectionLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UPTProtectionLevel.h; path = Classes/UPTProtectionLevel.h; sourceTree = "<group>"; };
 		BE4D0AFF20EEC8990027EAAC /* UPTHDSignerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UPTHDSignerSpec.m; sourceTree = "<group>"; };
 		BE5B094B20EAC08D00E44FCF /* UPTEthereumSignerTestHostApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UPTEthereumSignerTestHostApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE5B094D20EAC08E00E44FCF /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -179,6 +180,7 @@
 		BECA74CA20D9CBF7002793C8 /* UPTEthereumSigner */ = {
 			isa = PBXGroup;
 			children = (
+				BE018FA420EF1C460009CD36 /* UPTProtectionLevel.h */,
 				BE7FDBBA20D9CC9500D66B37 /* keccak.c */,
 				BE7FDBB720D9CC9500D66B37 /* keccak.h */,
 				BE7FDBBB20D9CC9500D66B37 /* UPTEthereumSigner.h */,

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.h
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.h
@@ -8,35 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM( NSInteger, UPTEthKeychainProtectionLevel ) {
-  /// @description stores key via VALValet with VALAccessibilityWhenUnlockedThisDeviceOnly
-  UPTEthKeychainProtectionLevelNormal = 0,
-  
-  /// @description stores key via VALSynchronizableValet
-  UPTEthKeychainProtectionLevelICloud,
-  
-  /// @description stores key via VALSecureEnclaveValet
-  UPTEthKeychainProtectionLevelPromptSecureEnclave,
-  
-  /// @description stores key via VALSinglePromptSecureEnclaveValet
-  UPTEthKeychainProtectionLevelSinglePromptSecureEnclave,
-  
-  /// @description Indicates an invalid unrecognized storage level
-  ///  Debug strategy:
-  ///  1. confirm no typo on react native sender side,
-  ///  2. confirm parity with android levels
-  ///  3. maybe update string constants in this class
-  UPTEthKeychainProtectionLevelNotRecognized = NSNotFound
-};
+#import "UPTProtectionLevel.h"
 
 ///
-/// @description: these strings are the possible strings passed in from react native as indicated in clubhouse task 2565
 ///
-FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelNormal;
-FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelICloud;
-FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelPromptSecureEnclave;
-FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelSinglePromptSecureEnclave;
-
 /// @description level param is not recognized by the system
 /// @debugStrategy add support for new level value or fix possible typo or incompatibility error on react native js side
 FOUNDATION_EXPORT NSString * const UPTSignerErrorCodeLevelParamNotRecognized;

--- a/UPTEthereumSigner/Classes/UPTHDSigner.h
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.h
@@ -8,35 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM( NSInteger, UPTHDSignerProtectionLevel ) {
-  /// @description stores key via VALValet with VALAccessibilityWhenUnlockedThisDeviceOnly
-  UPTHDSignerProtectionLevelNormal = 0,
-  
-  /// @description stores key via VALSynchronizableValet
-  UPTHDSignerProtectionLevelICloud,
-  
-  /// @description stores key via VALSecureEnclaveValet
-  UPTHDSignerProtectionLevelPromptSecureEnclave,
-  
-  /// @description stores key via VALSinglePromptSecureEnclaveValet
-  UPTHDSignerProtectionLevelSinglePromptSecureEnclave,
-  
-  /// @description Indicates an invalid unrecognized storage level
-  ///  Debug strategy:
-  ///  1. confirm no typo on react native sender side,
-  ///  2. confirm parity with android levels
-  ///  3. maybe update string constants in this class
-  UPTHDSignerProtectionLevelNotRecognized = NSNotFound
-};
-
-///
-/// @description: these strings are the possible strings passed in from react native as indicated in clubhouse task 2565
-///
-FOUNDATION_EXPORT NSString *const ReactNativeHDSignerProtectionLevelNormal;
-FOUNDATION_EXPORT NSString *const ReactNativeHDSignerProtectionLevelICloud;
-FOUNDATION_EXPORT NSString *const ReactNativeHDSignerProtectionLevelPromptSecureEnclave;
-FOUNDATION_EXPORT NSString *const ReactNativeHDSignerProtectionLevelSinglePromptSecureEnclave;
-
+#import "UPTProtectionLevel.h"
 
 /// @param ethAddress    an Ethereum adderss with prefix '0x'. May be nil if error occured
 /// @param publicKey    a base 64 encoded representation of the NSData public key. Note: encoded with no line

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -17,11 +17,6 @@
 NSString * const UPORT_ROOT_DERIVATION_PATH = @"m/7696500'/0'/0'/0'";
 NSString * const METAMASK_ROOT_DERIVATION_PATH = @"m/44'/60'/0'/0";
 
-NSString *const ReactNativeHDSignerProtectionLevelNormal = @"simple";
-NSString *const ReactNativeHDSignerProtectionLevelICloud = @"cloud"; // icloud keychain backup
-NSString *const ReactNativeHDSignerProtectionLevelPromptSecureEnclave = @"prompt";
-NSString *const ReactNativeHDSignerProtectionLevelSinglePromptSecureEnclave = @"singleprompt";
-
 /// @description identifiers so valet can encapsulate our keys in the keychain
 NSString *const UPTHDPrivateKeyIdentifier = @"UportPrivateKeys";
 NSString *const UPTHDProtectionLevelIdentifier = @"UportProtectionLevelIdentifier";

--- a/UPTEthereumSigner/Classes/UPTProtectionLevel.h
+++ b/UPTEthereumSigner/Classes/UPTProtectionLevel.h
@@ -1,0 +1,38 @@
+#import <Foundation/Foundation.h>
+
+/// @description: these strings are the possible strings passed in from react native as indicated in clubhouse task 2565
+FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelNormal;
+FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelICloud;
+FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelPromptSecureEnclave;
+FOUNDATION_EXPORT NSString *const ReactNativeKeychainProtectionLevelSinglePromptSecureEnclave;
+#define ReactNativeHDSignerProtectionLevelNormal ReactNativeKeychainProtectionLevelNormal
+#define ReactNativeHDSignerProtectionLevelICloud ReactNativeKeychainProtectionLevelICloud
+#define ReactNativeHDSignerProtectionLevelPromptSecureEnclave ReactNativeKeychainProtectionLevelPromptSecureEnclave
+#define ReactNativeHDSignerProtectionLevelSinglePromptSecureEnclave ReactNativeKeychainProtectionLevelSinglePromptSecureEnclave
+
+typedef NS_ENUM( NSInteger, UPTEthKeychainProtectionLevel ) {
+  /// @description stores key via VALValet with VALAccessibilityWhenUnlockedThisDeviceOnly
+  UPTEthKeychainProtectionLevelNormal = 0,
+  
+  /// @description stores key via VALSynchronizableValet
+  UPTEthKeychainProtectionLevelICloud,
+  
+  /// @description stores key via VALSecureEnclaveValet
+  UPTEthKeychainProtectionLevelPromptSecureEnclave,
+  
+  /// @description stores key via VALSinglePromptSecureEnclaveValet
+  UPTEthKeychainProtectionLevelSinglePromptSecureEnclave,
+  
+  /// @description Indicates an invalid unrecognized storage level
+  ///  Debug strategy:
+  ///  1. confirm no typo on react native sender side,
+  ///  2. confirm parity with android levels
+  ///  3. maybe update string constants in this class
+  UPTEthKeychainProtectionLevelNotRecognized = NSNotFound
+};
+#define UPTHDSignerProtectionLevel UPTEthKeychainProtectionLevel
+#define UPTHDSignerProtectionLevelNormal UPTEthKeychainProtectionLevelNormal
+#define UPTHDSignerProtectionLevelICloud UPTEthKeychainProtectionLevelICloud
+#define UPTHDSignerProtectionLevelPromptSecureEnclave UPTEthKeychainProtectionLevelPromptSecureEnclave
+#define UPTHDSignerProtectionLevelSinglePromptSecureEnclave UPTEthKeychainProtectionLevelSinglePromptSecureEnclave
+#define UPTHDSignerProtectionLevelNotRecognized UPTEthKeychainProtectionLevelNotRecognized


### PR DESCRIPTION
Closes https://github.com/uport-project/UPTEthereumSigner/issues/12
#### Changes
This removes some of the duplication regarding protection levels, except for enumStorageLevelWithStorageLevel.
This should not require any changes for consumers.
Reviewers @joshuabell