### PR TITLE
Reject Invalid Seed Words with Error

### DIFF
--- a/UPTEthereumSigner/Classes/UPTHDSigner.h
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.h
@@ -27,6 +27,7 @@ typedef void (^UPTHDSignerPrivateKeyResult)(NSString *privateKeyBase64, NSError 
 
 FOUNDATION_EXPORT NSString * const UPTHDSignerErrorCodeLevelParamNotRecognized;
 FOUNDATION_EXPORT NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound;
+FOUNDATION_EXPORT NSString * const UPTHDSignerErrorCodeInvalidSeedWords;
 
 FOUNDATION_EXPORT NSString * const UPORT_ROOT_DERIVATION_PATH;
 FOUNDATION_EXPORT NSString * const METAMASK_ROOT_DERIVATION_PATH;
@@ -46,6 +47,7 @@ FOUNDATION_EXPORT NSString * const METAMASK_ROOT_DERIVATION_PATH;
 /// @param  callback     a root account Ethereum address and root account public key
 + (void)importSeed:(UPTHDSignerProtectionLevel)protectionLevel phrase:(NSString *)phrase callback:(UPTHDSignerSeedCreationResult)callback __attribute__((deprecated));
 + (void)importSeed:(UPTHDSignerProtectionLevel)protectionLevel phrase:(NSString *)phrase rootDerivationPath:(NSString *)rootDerivationPath callback:(UPTHDSignerSeedCreationResult)callback;
++ (void)importSeed:(UPTHDSignerProtectionLevel)protectionLevel words:(NSArray<NSString *> *)words rootDerivationPath:(NSString *)rootDerivationPath callback:(UPTHDSignerSeedCreationResult)callback;
 
 /// @param  address     a root account Ethereum address
 /// @param  callback    the derived Ethereum address and derived public key

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -26,8 +26,10 @@ NSString *const UPTHDAddressIdentifier = @"UportEthAddressIdentifier";
 NSString *const UPTHDEntropyLookupKeyNamePrefix = @"seed-";
 NSString *const UPTHDEntropyProtectionLevelLookupKeyNamePrefix = @"level-seed-";
 
+NSString * const kUPTHDSignerErrorDomain = @"UPTHDSignerError";
 NSString * const UPTHDSignerErrorCodeLevelParamNotRecognized = @"-11";
 NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
+NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
 
 @implementation UPTHDSigner
 
@@ -49,7 +51,7 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 + (void)showSeed:(NSString *)rootAddress prompt:(NSString *)prompt callback:(UPTHDSignerSeedPhraseResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTHDSignerError" code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }
@@ -96,11 +98,33 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 }
 + (void)importSeed:(UPTHDSignerProtectionLevel)protectionLevel
     phrase:(NSString *)phrase
-    rootDerivationPath:(NSString *)derivationPath
+    rootDerivationPath:(NSString *)rootDerivationPath
     callback:(UPTHDSignerSeedCreationResult)callback
 {
     NSArray<NSString *> *words = [UPTHDSigner wordsFromPhrase:phrase];
+    [UPTHDSigner
+        importSeed:protectionLevel
+        words:words
+        rootDerivationPath:rootDerivationPath
+        callback:callback
+    ];
+}
++ (void)importSeed:(UPTHDSignerProtectionLevel)protectionLevel
+    words:(NSArray<NSString *> *)words
+    rootDerivationPath:(NSString *)derivationPath
+    callback:(UPTHDSignerSeedCreationResult)callback
+{
     BTCMnemonic *mnemonic = [[BTCMnemonic alloc] initWithWords:words password:@"" wordListType:BTCMnemonicWordListTypeEnglish];
+    if (!mnemonic) {
+        callback(nil, nil, [[NSError alloc]
+            initWithDomain:kUPTHDSignerErrorDomain
+            code:UPTHDSignerErrorCodeInvalidSeedWords.integerValue
+            userInfo:@{
+                @"message": @"Invalid seed phrase checksum"
+            }
+        ]);
+        return;
+    }
     BTCKeychain *masterKeychain = [[BTCKeychain alloc] initWithSeed:mnemonic.seed];
 
     BTCKeychain *rootKeychain = [masterKeychain derivedKeychainWithPath:derivationPath];
@@ -119,7 +143,7 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 + (void)computeAddressForPath:(NSString *)rootAddress derivationPath:(NSString *)derivationPath prompt:(NSString *)prompt callback:(UPTHDSignerSeedCreationResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTHDSignerError" code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
         callback( nil, nil, protectionLevelError);
         return;
     }
@@ -143,7 +167,7 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 + (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath txPayload:(NSString *)txPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTHDSignerError" code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }
@@ -168,14 +192,14 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 + (void)signJWT:(NSString *)rootAddress derivationPath:(NSString *)derivationPath data:(NSString *)data prompt:(NSString *)prompt callback:(UPTHDSignerJWTSigningResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTHDSignerError" code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }
 
     NSData *masterEntropy = [UPTHDSigner entropyWithEthAddress:rootAddress userPromptText:prompt protectionLevel:protectionLevel];
     if (!masterEntropy) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTError" code:UPTHDSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }
@@ -195,7 +219,7 @@ NSString * const UPTHDSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 + (void)privateKeyForPath:(NSString *)rootAddress derivationPath:(NSString *)derivationPath prompt:(NSString *)prompt callback:(UPTHDSignerPrivateKeyResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTHDSignerError" code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -199,7 +199,7 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
 
     NSData *masterEntropy = [UPTHDSigner entropyWithEthAddress:rootAddress userPromptText:prompt protectionLevel:protectionLevel];
     if (!masterEntropy) {
-        NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
+        NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTError" code:UPTHDSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
         callback( nil, protectionLevelError);
         return;
     }

--- a/UPTEthereumSignerTests/UPTHDSignerSpec.m
+++ b/UPTEthereumSignerTests/UPTHDSignerSpec.m
@@ -62,6 +62,19 @@ describe(@"key creation, address retrieval", ^{
             }
         ];
     });
+
+    it(@"rejects invalid phrases", ^{
+        [UPTHDSigner
+            importSeed:UPTHDSignerProtectionLevelPromptSecureEnclave
+            phrase:@"then cat cat cat cat cat cat cat cat cat cat cat"
+            rootDerivationPath:UPORT_ROOT_DERIVATION_PATH
+            callback:^(NSString *rootEthAddress, NSString *publicKey, NSError *error) {
+                expect(rootEthAddress).to.beNil();
+                expect(publicKey).to.beNil();
+                expect(error.code).to.equal(UPTHDSignerErrorCodeInvalidSeedWords.integerValue);
+            }
+        ];
+    });
 });
 
 SpecEnd


### PR DESCRIPTION

#### Changes
This returns nil,nil,error when BTCMnemonic fails validation.
This also creates a new import method so I can pass seed words without first joining them, since they will be immediately split.
Reviewers @joshuabell