### PR TITLE
Support EIP155

### DIFF
--- a/UPTEthereumSigner.xcodeproj/project.pbxproj
+++ b/UPTEthereumSigner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BE9AACD820DAC81A00C9BA17 /* ReferenceData.plist in Resources */ = {isa = PBXBuildFile; fileRef = BE9AACD720DAC81A00C9BA17 /* ReferenceData.plist */; };
 		BE9AACDF20DACA8000C9BA17 /* SignerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9AACDE20DACA8000C9BA17 /* SignerTests.m */; };
 		BEB5EA6B20DAC64E005239B2 /* libUPTEthereumSigner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BECA74C820D9CBF7002793C8 /* libUPTEthereumSigner.a */; };
+		BEE21FFE2108142E00564078 /* EthereumSigner.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE21FFD2108142E00564078 /* EthereumSigner.m */; };
 		CC8F5BF8609D43050A61DD3C /* Pods_UPTEthereumSigner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D81C0305A79098E2D3A8A94 /* Pods_UPTEthereumSigner.framework */; };
 		D2009D9B1E6E058DBEA76489 /* Pods_UPTEthereumSignerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 803379E1C20F6073CAC656C7 /* Pods_UPTEthereumSignerTests.framework */; };
 /* End PBXBuildFile section */
@@ -88,6 +89,8 @@
 		BEB5EA6A20DAC64E005239B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BEC940E020E9F51700782F06 /* Specta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Specta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BECA74C820D9CBF7002793C8 /* libUPTEthereumSigner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUPTEthereumSigner.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEE21FFC2108142E00564078 /* EthereumSigner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EthereumSigner.h; path = Classes/EthereumSigner.h; sourceTree = "<group>"; };
+		BEE21FFD2108142E00564078 /* EthereumSigner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EthereumSigner.m; path = Classes/EthereumSigner.m; sourceTree = "<group>"; };
 		FDB2564AFD663FA6879A0761 /* Pods-UPTEthereumSignerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UPTEthereumSignerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UPTEthereumSignerTests/Pods-UPTEthereumSignerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -180,13 +183,15 @@
 		BECA74CA20D9CBF7002793C8 /* UPTEthereumSigner */ = {
 			isa = PBXGroup;
 			children = (
-				BE018FA420EF1C460009CD36 /* UPTProtectionLevel.h */,
+				BEE21FFC2108142E00564078 /* EthereumSigner.h */,
+				BEE21FFD2108142E00564078 /* EthereumSigner.m */,
 				BE7FDBBA20D9CC9500D66B37 /* keccak.c */,
 				BE7FDBB720D9CC9500D66B37 /* keccak.h */,
 				BE7FDBBB20D9CC9500D66B37 /* UPTEthereumSigner.h */,
 				BE7FDBB820D9CC9500D66B37 /* UPTEthereumSigner.m */,
 				04C8DE7720D9E02E003381C2 /* UPTHDSigner.h */,
 				04C8DE7820D9E02E003381C2 /* UPTHDSigner.m */,
+				BE018FA420EF1C460009CD36 /* UPTProtectionLevel.h */,
 			);
 			path = UPTEthereumSigner;
 			sourceTree = "<group>";
@@ -414,6 +419,7 @@
 			files = (
 				04C8DE7B20D9E02E003381C2 /* UPTHDSigner.m in Sources */,
 				BE7FDBBE20D9CC9500D66B37 /* keccak.c in Sources */,
+				BEE21FFE2108142E00564078 /* EthereumSigner.m in Sources */,
 				BE7FDBBC20D9CC9500D66B37 /* UPTEthereumSigner.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UPTEthereumSigner.xcodeproj/project.pbxproj
+++ b/UPTEthereumSigner.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		BE9AACDF20DACA8000C9BA17 /* SignerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE9AACDE20DACA8000C9BA17 /* SignerTests.m */; };
 		BEB5EA6B20DAC64E005239B2 /* libUPTEthereumSigner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BECA74C820D9CBF7002793C8 /* libUPTEthereumSigner.a */; };
 		BEE21FFE2108142E00564078 /* EthereumSigner.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE21FFD2108142E00564078 /* EthereumSigner.m */; };
+		BEE2200321087F9500564078 /* EthereumSignerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE2200221087F9500564078 /* EthereumSignerTest.m */; };
 		CC8F5BF8609D43050A61DD3C /* Pods_UPTEthereumSigner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D81C0305A79098E2D3A8A94 /* Pods_UPTEthereumSigner.framework */; };
 		D2009D9B1E6E058DBEA76489 /* Pods_UPTEthereumSignerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 803379E1C20F6073CAC656C7 /* Pods_UPTEthereumSignerTests.framework */; };
 /* End PBXBuildFile section */
@@ -91,6 +92,7 @@
 		BECA74C820D9CBF7002793C8 /* libUPTEthereumSigner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUPTEthereumSigner.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEE21FFC2108142E00564078 /* EthereumSigner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EthereumSigner.h; path = Classes/EthereumSigner.h; sourceTree = "<group>"; };
 		BEE21FFD2108142E00564078 /* EthereumSigner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EthereumSigner.m; path = Classes/EthereumSigner.m; sourceTree = "<group>"; };
+		BEE2200221087F9500564078 /* EthereumSignerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EthereumSignerTest.m; sourceTree = "<group>"; };
 		FDB2564AFD663FA6879A0761 /* Pods-UPTEthereumSignerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UPTEthereumSignerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UPTEthereumSignerTests/Pods-UPTEthereumSignerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -148,6 +150,7 @@
 		BEB5EA6720DAC64E005239B2 /* UPTEthereumSignerTests */ = {
 			isa = PBXGroup;
 			children = (
+				BEE2200221087F9500564078 /* EthereumSignerTest.m */,
 				BE4D0AFF20EEC8990027EAAC /* UPTHDSignerSpec.m */,
 				BE9AACE020DACAEE00C9BA17 /* Tests-Prefix.pch */,
 				BE9AACDE20DACA8000C9BA17 /* SignerTests.m */,
@@ -408,6 +411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEE2200321087F9500564078 /* EthereumSignerTest.m in Sources */,
 				BE4D0B0020EEC8990027EAAC /* UPTHDSignerSpec.m in Sources */,
 				BE9AACDF20DACA8000C9BA17 /* SignerTests.m in Sources */,
 			);

--- a/UPTEthereumSigner/Classes/EthereumSigner.h
+++ b/UPTEthereumSigner/Classes/EthereumSigner.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+#import "CoreBitcoin/BTCKey.h"
+
+NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId);
+NSDictionary *genericSignature(BTCKey *keypair, NSData *hash, BOOL lowS);
+NSData *simpleSignature(BTCKey *keypair, NSData *hash);

--- a/UPTEthereumSigner/Classes/EthereumSigner.m
+++ b/UPTEthereumSigner/Classes/EthereumSigner.m
@@ -217,6 +217,8 @@ NSDictionary *genericSignature(BTCKey *keypair, NSData *hash, BOOL lowS) {
   
     BN_bn2bin(r,rData.mutableBytes);
     BN_bn2bin(s,sData.mutableBytes);
+    BN_clear_free(r);
+    BN_clear_free(s);
     return @{
         @"r": rData,
         @"s": sData

--- a/UPTEthereumSigner/Classes/EthereumSigner.m
+++ b/UPTEthereumSigner/Classes/EthereumSigner.m
@@ -1,0 +1,239 @@
+#import "EthereumSigner.h"
+
+#import "CoreBitcoin/CoreBitcoin+Categories.h"
+#import "CoreBitcoin/BTCKey.h"
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/obj_mac.h>
+
+static int BTCRegenerateKey(EC_KEY *eckey, BIGNUM *priv_key) {
+    BN_CTX *ctx = NULL;
+    EC_POINT *pub_key = NULL;
+
+    if (!eckey) return 0;
+
+    const EC_GROUP *group = EC_KEY_get0_group(eckey);
+
+    BOOL success = NO;
+    if ((ctx = BN_CTX_new())) {
+        if ((pub_key = EC_POINT_new(group))) {
+            if (EC_POINT_mul(group, pub_key, priv_key, NULL, NULL, ctx)) {
+                EC_KEY_set_private_key(eckey, priv_key);
+                EC_KEY_set_public_key(eckey, pub_key);
+                success = YES;
+            }
+        }
+    }
+
+    if (pub_key) EC_POINT_free(pub_key);
+    if (ctx) BN_CTX_free(ctx);
+
+    return success;
+}
+
+static int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, BIGNUM *r, BIGNUM *s, const unsigned char *msg, int msglen, int recid, int check) {
+    if (!eckey) return 0;
+
+    int ret = 0;
+    BN_CTX *ctx = NULL;
+
+    BIGNUM *x = NULL;
+    BIGNUM *e = NULL;
+    BIGNUM *order = NULL;
+    BIGNUM *sor = NULL;
+    BIGNUM *eor = NULL;
+    BIGNUM *field = NULL;
+    EC_POINT *R = NULL;
+    EC_POINT *O = NULL;
+    EC_POINT *Q = NULL;
+    BIGNUM *rr = NULL;
+    BIGNUM *zero = NULL;
+    int n = 0;
+    int i = recid / 2;
+
+    const EC_GROUP *group = EC_KEY_get0_group(eckey);
+    if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
+    BN_CTX_start(ctx);
+    order = BN_CTX_get(ctx);
+    if (!EC_GROUP_get_order(group, order, ctx)) { ret = -2; goto err; }
+    x = BN_CTX_get(ctx);
+    if (!BN_copy(x, order)) { ret=-1; goto err; }
+    if (!BN_mul_word(x, i)) { ret=-1; goto err; }
+    if (!BN_add(x, x, r)) { ret=-1; goto err; }
+    field = BN_CTX_get(ctx);
+    if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
+    if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
+    if ((R = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
+    if (!EC_POINT_set_compressed_coordinates_GFp(group, R, x, recid % 2, ctx)) { ret=0; goto err; }
+    if (check) {
+        if ((O = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
+        if (!EC_POINT_mul(group, O, NULL, R, order, ctx)) { ret=-2; goto err; }
+        if (!EC_POINT_is_at_infinity(group, O)) { ret = 0; goto err; }
+    }
+    if ((Q = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
+    n = EC_GROUP_get_degree(group);
+    e = BN_CTX_get(ctx);
+    if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
+    if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
+    zero = BN_CTX_get(ctx);
+    if (!BN_zero(zero)) { ret=-1; goto err; }
+    if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
+    rr = BN_CTX_get(ctx);
+    if (!BN_mod_inverse(rr, r, order, ctx)) { ret=-1; goto err; }
+    sor = BN_CTX_get(ctx);
+    if (!BN_mod_mul(sor, s, rr, order, ctx)) { ret=-1; goto err; }
+    eor = BN_CTX_get(ctx);
+    if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
+    if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
+    if (!EC_KEY_set_public_key(eckey, Q)) { ret=-2; goto err; }
+
+    ret = 1;
+
+    err:
+    if (ctx) {
+        BN_CTX_end(ctx);
+        BN_CTX_free(ctx);
+    }
+    if (R != NULL) EC_POINT_free(R);
+    if (O != NULL) EC_POINT_free(O);
+    if (Q != NULL) EC_POINT_free(Q);
+    return ret;
+}
+NSMutableData *compressedPublicKey(EC_KEY *key) {
+    if (!key) return nil;
+    EC_KEY_set_conv_form(key, POINT_CONVERSION_COMPRESSED);
+    int length = i2o_ECPublicKey(key, NULL);
+    if (!length) return nil;
+    NSCAssert(length <= 65, @"Pubkey length must be up to 65 bytes.");
+    NSMutableData* data = [[NSMutableData alloc] initWithLength:length];
+    unsigned char* bytes = [data mutableBytes];
+    if (i2o_ECPublicKey(key, &bytes) != length) return nil;
+    return data;
+}
+
+
+NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId) {
+    NSDictionary *sig = genericSignature(keypair, hash, YES);
+    NSData *rData = (NSData *)sig[@"r"];
+    NSData *sData = (NSData *)sig[@"s"];
+    int rec = -1;
+    const unsigned char* hashbytes = hash.bytes;
+    int hashlength = (int)hash.length;
+    BIGNUM *r = BN_new(); BN_bin2bn(rData.bytes ,32, r);
+    BIGNUM *s = BN_new(); BN_bin2bn(sData.bytes ,32, s);
+    int nBitsR = BN_num_bits(r);
+    int nBitsS = BN_num_bits(s);
+    if (nBitsR <= 256 && nBitsS <= 256) {
+        NSData* pubkey = [keypair compressedPublicKey];
+        BOOL foundMatchingPubkey = NO;
+        for (int i=0; i < 4; i++) {
+            EC_KEY* key2 = EC_KEY_new_by_curve_name(NID_secp256k1);
+            if (ECDSA_SIG_recover_key_GFp(key2, r, s, hashbytes, hashlength, i, 1) == 1) {
+                NSData* pubkey2 = compressedPublicKey(key2);
+                if ([pubkey isEqual:pubkey2]) {
+                    rec = i;
+                    foundMatchingPubkey = YES;
+                    break;
+                }
+            }
+        }
+        NSCAssert(foundMatchingPubkey, @"At least one signature must work.");
+    }
+    BN_clear_free(r);
+    BN_clear_free(s);
+    BN_ULONG base = 0x1b; // pre-EIP155
+    if (chainId) {
+        BIGNUM *v = BN_new(); BN_bin2bn(chainId.bytes, chainId.length, v);
+        // TODO support longer chainIDs
+        base = BN_get_word(v) * 2 + 35;
+        BN_clear_free(v);
+    }
+
+    NSDictionary *signatureDictionary = @{ @"v": @(base + rec),
+            @"r": [rData base64EncodedStringWithOptions:0],
+            @"s":[sData base64EncodedStringWithOptions:0]};
+    return signatureDictionary;
+}
+
+
+NSDictionary *genericSignature(BTCKey *keypair, NSData *hash, BOOL lowS) {
+    NSMutableData *privateKey = [keypair privateKey];
+    EC_KEY* key = EC_KEY_new_by_curve_name(NID_secp256k1);
+
+    BIGNUM *bignum = BN_bin2bn(privateKey.bytes, (int)privateKey.length, BN_new());
+    BTCRegenerateKey(key, bignum);
+
+
+    const BIGNUM *privkeyBIGNUM = EC_KEY_get0_private_key(key);
+
+    BTCMutableBigNumber* privkeyBN = [[BTCMutableBigNumber alloc] initWithBIGNUM:privkeyBIGNUM];
+    BTCBigNumber* n = [BTCCurvePoint curveOrder];
+
+    NSMutableData* kdata = [keypair signatureNonceForHash:hash];
+    BTCMutableBigNumber* k = [[BTCMutableBigNumber alloc] initWithUnsignedBigEndian:kdata];
+    [k mod:n]; // make sure k belongs to [0, n - 1]
+
+    BTCDataClear(kdata);
+
+    BTCCurvePoint* K = [[BTCCurvePoint generator] multiply:k];
+    BTCBigNumber* Kx = K.x;
+
+    BTCBigNumber* hashBN = [[BTCBigNumber alloc] initWithUnsignedBigEndian:hash];
+
+    // Compute s = (k^-1)*(h + Kx*privkey)
+
+    BTCBigNumber* signatureBN = [[[privkeyBN multiply:Kx mod:n] add:hashBN mod:n] multiply:[k inverseMod:n] mod:n];
+
+    BIGNUM *r = BN_new(); BN_copy(r, Kx.BIGNUM);
+    BIGNUM *s = BN_new(); BN_copy(s, signatureBN.BIGNUM);
+  
+    BN_clear_free(bignum);
+    BTCDataClear(privateKey);
+    [privkeyBN clear];
+    [k clear];
+    [hashBN clear];
+    [K clear];
+    [Kx clear];
+    [signatureBN clear];
+
+    BN_CTX *ctx = BN_CTX_new();
+    BN_CTX_start(ctx);
+
+    const EC_GROUP *group = EC_KEY_get0_group(key);
+    BIGNUM *order = BN_CTX_get(ctx);
+    BIGNUM *halforder = BN_CTX_get(ctx);
+    EC_GROUP_get_order(group, order, ctx);
+    BN_rshift1(halforder, order);
+    if (lowS && BN_cmp(s, halforder) > 0) {
+        // enforce low S values, by negating the value (modulo the order) if above order/2.
+        BN_sub(s, order, s);
+    }
+    EC_KEY_free(key);
+
+    BN_CTX_end(ctx);
+    BN_CTX_free(ctx);
+    NSMutableData* rData = [NSMutableData dataWithLength:32];
+    NSMutableData* sData = [NSMutableData dataWithLength:32];
+  
+    BN_bn2bin(r,rData.mutableBytes);
+    BN_bn2bin(s,sData.mutableBytes);
+    return @{
+        @"r": rData,
+        @"s": sData
+    };
+
+}
+
+NSData *simpleSignature(BTCKey *keypair, NSData *hash) {
+    NSDictionary *sig = genericSignature(keypair, hash, NO);
+    NSData *rData = (NSData *)sig[@"r"];
+    NSData *sData = (NSData *)sig[@"s"];
+    ///////
+    NSMutableData *sigData = [NSMutableData dataWithLength:64];
+    unsigned char* sigBytes = sigData.mutableBytes;
+    memset(sigBytes, 0, 64);
+
+    memcpy(sigBytes, rData.bytes, 32);
+    memcpy(sigBytes+32, sData.bytes, 32);
+    return sigData;
+}

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.h
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.h
@@ -34,8 +34,9 @@ typedef void (^UPTEthSignerJWTSigningResult)(NSData *signature, NSError *error);
 
 + (void)saveKey:(NSData *)privateKey protectionLevel:(UPTEthKeychainProtectionLevel)protectionLevel result:(UPTEthSignerKeyPairCreationResult)result;
 
-+ (void)signTransaction:(NSString *)ethAddress data:(NSString *)payload userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result;
-+ (void)signTransaction:(NSString *)ethAddress serializedTxPayload:(NSData *)serializedTxPayload userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result;
+// if you are supplying chainID, your tx payload contains 9 fields; otherwise it contains 6
++ (void)signTransaction:(NSString *)ethAddress data:(NSString *)payload userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result __attribute__((deprecated));
++ (void)signTransaction:(NSString *)ethAddress serializedTxPayload:(NSData *)serializedTxPayload chainId:(NSData *)chainId userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result;
 
 + (void)signJwt:(NSString *)ethAddress userPrompt:(NSString*)userPromptText data:(NSData *)payload result:(UPTEthSignerJWTSigningResult)result;
 

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.h
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.h
@@ -35,6 +35,7 @@ typedef void (^UPTEthSignerJWTSigningResult)(NSData *signature, NSError *error);
 + (void)saveKey:(NSData *)privateKey protectionLevel:(UPTEthKeychainProtectionLevel)protectionLevel result:(UPTEthSignerKeyPairCreationResult)result;
 
 + (void)signTransaction:(NSString *)ethAddress data:(NSString *)payload userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result;
++ (void)signTransaction:(NSString *)ethAddress serializedTxPayload:(NSData *)serializedTxPayload userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result;
 
 + (void)signJwt:(NSString *)ethAddress userPrompt:(NSString*)userPromptText data:(NSData *)payload result:(UPTEthSignerJWTSigningResult)result;
 

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.m
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.m
@@ -174,6 +174,15 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 }
 
 + (void)signTransaction:(NSString *)ethAddress data:(NSString *)payload userPrompt:(NSString*)userPromptText  result:(UPTEthSignerTransactionSigningResult)result {
+    NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:payload options:0];
+    [UPTEthereumSigner
+        signTransaction:ethAddress
+        serializedTxPayload:payloadData
+        userPrompt:userPromptText
+        result:result
+    ];
+}
++ (void)signTransaction:(NSString *)ethAddress serializedTxPayload:(NSData *)payloadData userPrompt:(NSString*)userPromptText result:(UPTEthSignerTransactionSigningResult)result {
     UPTEthKeychainProtectionLevel protectionLevel = [UPTEthereumSigner protectionLevelWithEthAddress:ethAddress];
     if ( protectionLevel == UPTEthKeychainProtectionLevelNotRecognized ) {
         NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTError" code:UPTSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
@@ -183,7 +192,6 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 
     BTCKey *key = [self keyPairWithEthAddress:ethAddress userPromptText:userPromptText protectionLevel:protectionLevel];
     if (key) {
-        NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:payload options:0];
         NSData *hash = [UPTEthereumSigner keccak256:payloadData];
         NSDictionary *signature = [self ethereumSignature: key forHash:hash];
         result(signature, nil);

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.m
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.m
@@ -159,7 +159,7 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
     if (chainId) {
         BIGNUM *v = BN_new(); BN_bin2bn(chainId.bytes, chainId.length, v);
         // TODO support longer chainIDs
-        base = BN_get_word(v);
+        base = BN_get_word(v) * 2 + 35;
         BN_clear_free(v);
     }
 

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.m
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.m
@@ -7,19 +7,10 @@
 //
 
 #import <Valet/Valet.h>
+#import "EthereumSigner.h"
 #import "UPTEthereumSigner.h"
 #import "CoreBitcoin/CoreBitcoin+Categories.h"
-#import <openssl/rand.h>
-#include <openssl/ec.h>
-#include <openssl/ecdsa.h>
-#include <openssl/bn.h>
-#include <openssl/evp.h>
-#include <openssl/obj_mac.h>
-#include <openssl/rand.h>
-#include "keccak.h"
-
-static int     BTCRegenerateKey(EC_KEY *eckey, BIGNUM *priv_key);
-static int     ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, BIGNUM *r, BIGNUM *s, const unsigned char *msg, int msglen, int recid, int check);
+#import "keccak.h"
 
 NSString *const ReactNativeKeychainProtectionLevelNormal = @"simple";
 NSString *const ReactNativeKeychainProtectionLevelICloud = @"cloud"; // icloud keychain backup
@@ -46,143 +37,6 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
 }
 
 
-+ (NSMutableData*) compressedPublicKey:(EC_KEY *)key {
-    if (!key) return nil;
-    EC_KEY_set_conv_form(key, POINT_CONVERSION_COMPRESSED);
-    int length = i2o_ECPublicKey(key, NULL);
-    if (!length) return nil;
-    NSAssert(length <= 65, @"Pubkey length must be up to 65 bytes.");
-    NSMutableData* data = [[NSMutableData alloc] initWithLength:length];
-    unsigned char* bytes = [data mutableBytes];
-    if (i2o_ECPublicKey(key, &bytes) != length) return nil;
-    return data;
-}
-
-// Handles most of the signing code
-+ (NSDictionary *) genericSignature:(BTCKey*)keypair forHash:(NSData*)hash enforceLowS: (BOOL)lowS {
-    NSMutableData *privateKey = [keypair privateKey];
-    EC_KEY* key = EC_KEY_new_by_curve_name(NID_secp256k1);
-
-    BIGNUM *bignum = BN_bin2bn(privateKey.bytes, (int)privateKey.length, BN_new());
-    BTCRegenerateKey(key, bignum);
-
-
-    const BIGNUM *privkeyBIGNUM = EC_KEY_get0_private_key(key);
-
-    BTCMutableBigNumber* privkeyBN = [[BTCMutableBigNumber alloc] initWithBIGNUM:privkeyBIGNUM];
-    BTCBigNumber* n = [BTCCurvePoint curveOrder];
-
-    NSMutableData* kdata = [keypair signatureNonceForHash:hash];
-    BTCMutableBigNumber* k = [[BTCMutableBigNumber alloc] initWithUnsignedBigEndian:kdata];
-    [k mod:n]; // make sure k belongs to [0, n - 1]
-
-    BTCDataClear(kdata);
-
-    BTCCurvePoint* K = [[BTCCurvePoint generator] multiply:k];
-    BTCBigNumber* Kx = K.x;
-
-    BTCBigNumber* hashBN = [[BTCBigNumber alloc] initWithUnsignedBigEndian:hash];
-
-    // Compute s = (k^-1)*(h + Kx*privkey)
-
-    BTCBigNumber* signatureBN = [[[privkeyBN multiply:Kx mod:n] add:hashBN mod:n] multiply:[k inverseMod:n] mod:n];
-
-    BIGNUM *r = BN_new(); BN_copy(r, Kx.BIGNUM);
-    BIGNUM *s = BN_new(); BN_copy(s, signatureBN.BIGNUM);
-  
-    BN_clear_free(bignum);
-    BTCDataClear(privateKey);
-    [privkeyBN clear];
-    [k clear];
-    [hashBN clear];
-    [K clear];
-    [Kx clear];
-    [signatureBN clear];
-
-    BN_CTX *ctx = BN_CTX_new();
-    BN_CTX_start(ctx);
-
-    const EC_GROUP *group = EC_KEY_get0_group(key);
-    BIGNUM *order = BN_CTX_get(ctx);
-    BIGNUM *halforder = BN_CTX_get(ctx);
-    EC_GROUP_get_order(group, order, ctx);
-    BN_rshift1(halforder, order);
-    if (lowS && BN_cmp(s, halforder) > 0) {
-        // enforce low S values, by negating the value (modulo the order) if above order/2.
-        BN_sub(s, order, s);
-    }
-    EC_KEY_free(key);
-
-    BN_CTX_end(ctx);
-    BN_CTX_free(ctx);
-    NSMutableData* rData = [NSMutableData dataWithLength:32];
-    NSMutableData* sData = [NSMutableData dataWithLength:32];
-  
-    BN_bn2bin(r,rData.mutableBytes);
-    BN_bn2bin(s,sData.mutableBytes);
-    return @{
-             @"r": rData,
-             @"s": sData
-             };
-}
-
-+ (NSDictionary*) ethereumSignature:(BTCKey*)keypair forHash:(NSData*)hash chainId:(NSData *)chainId {
-    NSDictionary *sig = [self genericSignature: keypair forHash: hash enforceLowS: YES];
-    NSData *rData = (NSData *)sig[@"r"];
-    NSData *sData = (NSData *)sig[@"s"];
-    int rec = -1;
-    const unsigned char* hashbytes = hash.bytes;
-    int hashlength = (int)hash.length;
-    BIGNUM *r = BN_new(); BN_bin2bn(rData.bytes ,32, r);
-    BIGNUM *s = BN_new(); BN_bin2bn(sData.bytes ,32, s);
-    int nBitsR = BN_num_bits(r);
-    int nBitsS = BN_num_bits(s);
-    if (nBitsR <= 256 && nBitsS <= 256) {
-        NSData* pubkey = [keypair compressedPublicKey];
-        BOOL foundMatchingPubkey = NO;
-        for (int i=0; i < 4; i++) {
-            EC_KEY* key2 = EC_KEY_new_by_curve_name(NID_secp256k1);
-            if (ECDSA_SIG_recover_key_GFp(key2, r, s, hashbytes, hashlength, i, 1) == 1) {
-                NSData* pubkey2 = [self compressedPublicKey: key2];
-                if ([pubkey isEqual:pubkey2]) {
-                    rec = i;
-                    foundMatchingPubkey = YES;
-                    break;
-                }
-            }
-        }
-        NSAssert(foundMatchingPubkey, @"At least one signature must work.");
-    }
-    BN_clear_free(r);
-    BN_clear_free(s);
-    BN_ULONG base = 0x1b; // pre-EIP155
-    if (chainId) {
-        BIGNUM *v = BN_new(); BN_bin2bn(chainId.bytes, chainId.length, v);
-        // TODO support longer chainIDs
-        base = BN_get_word(v) * 2 + 35;
-        BN_clear_free(v);
-    }
-
-    NSDictionary *signatureDictionary = @{ @"v": @(base + rec),
-            @"r": [rData base64EncodedStringWithOptions:0],
-            @"s":[sData base64EncodedStringWithOptions:0]};
-    return signatureDictionary;
-}
-
-+ (NSData*) simpleSignature:(BTCKey*)keypair forHash:(NSData*)hash {
-    NSDictionary *sig = [self genericSignature: keypair forHash: hash enforceLowS: NO];
-    NSData *rData = (NSData *)sig[@"r"];
-    NSData *sData = (NSData *)sig[@"s"];
-    ///////
-    NSMutableData *sigData = [NSMutableData dataWithLength:64];
-    unsigned char* sigBytes = sigData.mutableBytes;
-    memset(sigBytes, 0, 64);
-
-    memcpy(sigBytes, rData.bytes, 32);
-    memcpy(sigBytes+32, sData.bytes, 32);
-    return sigData;
-}
-
 + (void)signTransaction:(NSString *)ethAddress data:(NSString *)payload userPrompt:(NSString*)userPromptText  result:(UPTEthSignerTransactionSigningResult)result {
     NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:payload options:0];
     [UPTEthereumSigner
@@ -204,7 +58,7 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
     BTCKey *key = [self keyPairWithEthAddress:ethAddress userPromptText:userPromptText protectionLevel:protectionLevel];
     if (key) {
         NSData *hash = [UPTEthereumSigner keccak256:payloadData];
-        NSDictionary *signature = [self ethereumSignature:key forHash:hash chainId:(NSData *)chainId];
+        NSDictionary *signature = ethereumSignature(key, hash, chainId);
         result(signature, nil);
     } else {
         NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTError" code:UPTSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
@@ -224,7 +78,7 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
     BTCKey *key = [self keyPairWithEthAddress:ethAddress userPromptText:userPromptText protectionLevel:protectionLevel];
     if (key) {
         NSData *hash = [payload SHA256];
-        NSData *signature = [self simpleSignature:key forHash:hash];
+        NSData *signature = simpleSignature(key, hash);
         result(signature, nil);
     } else {
         NSError *protectionLevelError = [[NSError alloc] initWithDomain:@"UPTError" code:UPTSignerErrorCodeLevelPrivateKeyNotFound.integerValue userInfo:@{@"message": @"private key not found for eth address"}];
@@ -393,103 +247,6 @@ NSString * const UPTSignerErrorCodeLevelPrivateKeyNotFound = @"-12";
     }
 
     return keystore;
-}
-
-static int BTCRegenerateKey(EC_KEY *eckey, BIGNUM *priv_key) {
-    BN_CTX *ctx = NULL;
-    EC_POINT *pub_key = NULL;
-
-    if (!eckey) return 0;
-
-    const EC_GROUP *group = EC_KEY_get0_group(eckey);
-
-    BOOL success = NO;
-    if ((ctx = BN_CTX_new())) {
-        if ((pub_key = EC_POINT_new(group))) {
-            if (EC_POINT_mul(group, pub_key, priv_key, NULL, NULL, ctx)) {
-                EC_KEY_set_private_key(eckey, priv_key);
-                EC_KEY_set_public_key(eckey, pub_key);
-                success = YES;
-            }
-        }
-    }
-
-    if (pub_key) EC_POINT_free(pub_key);
-    if (ctx) BN_CTX_free(ctx);
-
-    return success;
-}
-
-// Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
-// recid selects which key is recovered
-// if check is non-zero, additional checks are performed
-static int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, BIGNUM *r, BIGNUM *s, const unsigned char *msg, int msglen, int recid, int check) {
-    if (!eckey) return 0;
-
-    int ret = 0;
-    BN_CTX *ctx = NULL;
-
-    BIGNUM *x = NULL;
-    BIGNUM *e = NULL;
-    BIGNUM *order = NULL;
-    BIGNUM *sor = NULL;
-    BIGNUM *eor = NULL;
-    BIGNUM *field = NULL;
-    EC_POINT *R = NULL;
-    EC_POINT *O = NULL;
-    EC_POINT *Q = NULL;
-    BIGNUM *rr = NULL;
-    BIGNUM *zero = NULL;
-    int n = 0;
-    int i = recid / 2;
-
-    const EC_GROUP *group = EC_KEY_get0_group(eckey);
-    if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
-    BN_CTX_start(ctx);
-    order = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_order(group, order, ctx)) { ret = -2; goto err; }
-    x = BN_CTX_get(ctx);
-    if (!BN_copy(x, order)) { ret=-1; goto err; }
-    if (!BN_mul_word(x, i)) { ret=-1; goto err; }
-    if (!BN_add(x, x, r)) { ret=-1; goto err; }
-    field = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
-    if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
-    if ((R = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    if (!EC_POINT_set_compressed_coordinates_GFp(group, R, x, recid % 2, ctx)) { ret=0; goto err; }
-    if (check) {
-        if ((O = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-        if (!EC_POINT_mul(group, O, NULL, R, order, ctx)) { ret=-2; goto err; }
-        if (!EC_POINT_is_at_infinity(group, O)) { ret = 0; goto err; }
-    }
-    if ((Q = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    n = EC_GROUP_get_degree(group);
-    e = BN_CTX_get(ctx);
-    if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
-    if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
-    zero = BN_CTX_get(ctx);
-    if (!BN_zero(zero)) { ret=-1; goto err; }
-    if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
-    rr = BN_CTX_get(ctx);
-    if (!BN_mod_inverse(rr, r, order, ctx)) { ret=-1; goto err; }
-    sor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(sor, s, rr, order, ctx)) { ret=-1; goto err; }
-    eor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
-    if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
-    if (!EC_KEY_set_public_key(eckey, Q)) { ret=-2; goto err; }
-
-    ret = 1;
-
-    err:
-    if (ctx) {
-        BN_CTX_end(ctx);
-        BN_CTX_free(ctx);
-    }
-    if (R != NULL) EC_POINT_free(R);
-    if (O != NULL) EC_POINT_free(O);
-    if (Q != NULL) EC_POINT_free(Q);
-    return ret;
 }
 
 #pragma mark - Utils

--- a/UPTEthereumSigner/Classes/UPTHDSigner.h
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.h
@@ -56,6 +56,7 @@ FOUNDATION_EXPORT NSString * const METAMASK_ROOT_DERIVATION_PATH;
 
 /// @param  ethereumAddress     a root account Ethereum address
 + (void)signTransaction:(NSString *)ethereumAddress derivationPath:(NSString *)derivationPath txPayload:(NSString *)txPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback;
++ (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath serializedTxPayload:(NSData *)serializedTxPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback;
 
 /// @param  ethereumAddress     a root account Ethereum address
 + (void)signJWT:(NSString *)ethereumAddress derivationPath:(NSString *)derivationPath data:(NSString *)data prompt:(NSString *)prompt callback:(UPTHDSignerJWTSigningResult)callback;

--- a/UPTEthereumSigner/Classes/UPTHDSigner.h
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.h
@@ -54,9 +54,10 @@ FOUNDATION_EXPORT NSString * const METAMASK_ROOT_DERIVATION_PATH;
 + (void)computeAddressForPath:(NSString *)address derivationPath:(NSString *)derivationPath prompt:(NSString *)prompt callback:(UPTHDSignerSeedCreationResult)callback;
 
 
+// if you are supplying chainID, your tx payload contains 9 fields; otherwise it contains 6
 /// @param  ethereumAddress     a root account Ethereum address
-+ (void)signTransaction:(NSString *)ethereumAddress derivationPath:(NSString *)derivationPath txPayload:(NSString *)txPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback;
-+ (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath serializedTxPayload:(NSData *)serializedTxPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback;
++ (void)signTransaction:(NSString *)ethereumAddress derivationPath:(NSString *)derivationPath txPayload:(NSString *)txPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback __attribute__((deprecated));
++ (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath serializedTxPayload:(NSData *)serializedTxPayload chainId:(NSData *)chainId prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback;
 
 /// @param  ethereumAddress     a root account Ethereum address
 + (void)signJWT:(NSString *)ethereumAddress derivationPath:(NSString *)derivationPath data:(NSString *)data prompt:(NSString *)prompt callback:(UPTHDSignerJWTSigningResult)callback;

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -165,6 +165,16 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
 }
 
 + (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath txPayload:(NSString *)txPayload prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback {
+    NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:txPayload options:0];
+    [UPTHDSigner
+        signTransaction:rootAddress
+        derivationPath:derivationPath
+        serializedTxPayload:payloadData
+        prompt:prompt
+        callback:callback
+    ];
+}
++ (void)signTransaction:(NSString *)rootAddress derivationPath:(NSString *)derivationPath serializedTxPayload:(NSData *)payloadData prompt:(NSString *)prompt callback:(UPTHDSignerTransactionSigningResult)callback {
     UPTHDSignerProtectionLevel protectionLevel = [UPTHDSigner protectionLevelWithEthAddress:rootAddress];
     if ( protectionLevel == UPTHDSignerProtectionLevelNotRecognized ) {
         NSError *protectionLevelError = [[NSError alloc] initWithDomain:kUPTHDSignerErrorDomain code:UPTHDSignerErrorCodeLevelParamNotRecognized.integerValue userInfo:@{@"message": @"protection level not found for eth address"}];
@@ -183,7 +193,6 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
     BTCKeychain *masterKeychain = [[BTCKeychain alloc] initWithSeed:mnemonic.seed];
     BTCKeychain *derivedKeychain = [masterKeychain derivedKeychainWithPath:derivationPath];
 
-    NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:txPayload options:0];
     NSData *hash = [UPTHDSigner keccak256:payloadData];
     NSDictionary *signature = [self ethereumSignature: derivedKeychain.key forHash:hash];
     callback(signature, nil);

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -490,7 +490,7 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
     if (chainId) {
         BIGNUM *v = BN_new(); BN_bin2bn(chainId.bytes, chainId.length, v);
         // TODO support longer chainIDs
-        base = BN_get_word(v);
+        base = BN_get_word(v) * 2 + 35;
         BN_clear_free(v);
     }
 

--- a/UPTEthereumSigner/Classes/UPTHDSigner.m
+++ b/UPTEthereumSigner/Classes/UPTHDSigner.m
@@ -7,10 +7,10 @@
 //
 
 #import "UPTHDSigner.h"
+#import "EthereumSigner.h"
 #import "CoreBitcoin/BTCMnemonic.h"
 #import "keccak.h"
 #import "CoreBitcoin/CoreBitcoin+Categories.h"
-#import <openssl/obj_mac.h>
 #import <Valet/Valet.h>
 
 // https://github.com/ethereum/EIPs/issues/84
@@ -195,7 +195,7 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
     BTCKeychain *derivedKeychain = [masterKeychain derivedKeychainWithPath:derivationPath];
 
     NSData *hash = [UPTHDSigner keccak256:payloadData];
-    NSDictionary *signature = [self ethereumSignature:derivedKeychain.key forHash:hash chainId:chainId];
+    NSDictionary *signature = ethereumSignature(derivedKeychain.key, hash, chainId);
     callback(signature, nil);
 }
 
@@ -220,7 +220,7 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
 
     NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:data options:0];
     NSData *hash = [payloadData SHA256];
-    NSData *signature = [self simpleSignature:derivedKeychain.key forHash:hash];
+    NSData *signature = simpleSignature(derivedKeychain.key, hash);
     NSString *base64EncodedSignature = [signature base64EncodedStringWithOptions:0];
     NSString *webSafeBase64Signature = [UPTHDSigner URLEncodedBase64StringWithBase64String:base64EncodedSignature];
     callback(webSafeBase64Signature, nil);
@@ -387,228 +387,6 @@ NSString * const UPTHDSignerErrorCodeInvalidSeedWords = @"-13";
     unsigned char* bytes = [data mutableBytes];
     if (i2o_ECPublicKey(key, &bytes) != length) return nil;
     return data;
-}
-
-// Handles most of the signing code
-+ (NSDictionary *) genericSignature:(BTCKey*)keypair forHash:(NSData*)hash enforceLowS: (BOOL)lowS {
-    NSMutableData *privateKey = [keypair privateKey];
-    EC_KEY* key = EC_KEY_new_by_curve_name(NID_secp256k1);
-
-    BIGNUM *bignum = BN_bin2bn(privateKey.bytes, (int)privateKey.length, BN_new());
-    BTCRegenerateKey(key, bignum);
-
-
-    const BIGNUM *privkeyBIGNUM = EC_KEY_get0_private_key(key);
-
-    BTCMutableBigNumber* privkeyBN = [[BTCMutableBigNumber alloc] initWithBIGNUM:privkeyBIGNUM];
-    BTCBigNumber* n = [BTCCurvePoint curveOrder];
-
-    NSMutableData* kdata = [keypair signatureNonceForHash:hash];
-    BTCMutableBigNumber* k = [[BTCMutableBigNumber alloc] initWithUnsignedBigEndian:kdata];
-    [k mod:n]; // make sure k belongs to [0, n - 1]
-
-    BTCDataClear(kdata);
-
-    BTCCurvePoint* K = [[BTCCurvePoint generator] multiply:k];
-    BTCBigNumber* Kx = K.x;
-
-    BTCBigNumber* hashBN = [[BTCBigNumber alloc] initWithUnsignedBigEndian:hash];
-
-    // Compute s = (k^-1)*(h + Kx*privkey)
-
-    BTCBigNumber* signatureBN = [[[privkeyBN multiply:Kx mod:n] add:hashBN mod:n] multiply:[k inverseMod:n] mod:n];
-
-    BIGNUM *r = BN_new(); BN_copy(r, Kx.BIGNUM);
-    BIGNUM *s = BN_new(); BN_copy(s, signatureBN.BIGNUM);
-
-    BN_clear_free(bignum);
-    BTCDataClear(privateKey);
-    [privkeyBN clear];
-    [k clear];
-    [hashBN clear];
-    [K clear];
-    [Kx clear];
-    [signatureBN clear];
-
-    BN_CTX *ctx = BN_CTX_new();
-    BN_CTX_start(ctx);
-
-    const EC_GROUP *group = EC_KEY_get0_group(key);
-    BIGNUM *order = BN_CTX_get(ctx);
-    BIGNUM *halforder = BN_CTX_get(ctx);
-    EC_GROUP_get_order(group, order, ctx);
-    BN_rshift1(halforder, order);
-    if (lowS && BN_cmp(s, halforder) > 0) {
-        // enforce low S values, by negating the value (modulo the order) if above order/2.
-        BN_sub(s, order, s);
-    }
-    EC_KEY_free(key);
-
-    BN_CTX_end(ctx);
-    BN_CTX_free(ctx);
-    NSMutableData* rData = [NSMutableData dataWithLength:32];
-    NSMutableData* sData = [NSMutableData dataWithLength:32];
-
-    BN_bn2bin(r,rData.mutableBytes);
-    BN_bn2bin(s,sData.mutableBytes);
-    return @{
-            @"r": rData,
-            @"s": sData
-    };
-}
-
-+ (NSDictionary *)ethereumSignature:(BTCKey *)keypair forHash:(NSData *)hash chainId:(NSData *)chainId {
-    NSDictionary *sig = [self genericSignature: keypair forHash: hash enforceLowS: YES];
-    NSData *rData = (NSData *)sig[@"r"];
-    NSData *sData = (NSData *)sig[@"s"];
-    int rec = -1;
-    const unsigned char* hashbytes = hash.bytes;
-    int hashlength = (int)hash.length;
-    BIGNUM *r = BN_new(); BN_bin2bn(rData.bytes, 32, r);
-    BIGNUM *s = BN_new(); BN_bin2bn(sData.bytes, 32, s);
-    int nBitsR = BN_num_bits(r);
-    int nBitsS = BN_num_bits(s);
-    if (nBitsR <= 256 && nBitsS <= 256) {
-        NSData* pubkey = [keypair compressedPublicKey];
-        BOOL foundMatchingPubkey = NO;
-        for (int i=0; i < 4; i++) {
-            EC_KEY* key2 = EC_KEY_new_by_curve_name(NID_secp256k1);
-            if (ECDSA_SIG_recover_key_GFp(key2, r, s, hashbytes, hashlength, i, 1) == 1) {
-                NSData* pubkey2 = [self compressedPublicKey: key2];
-                if ([pubkey isEqual:pubkey2]) {
-                    rec = i;
-                    foundMatchingPubkey = YES;
-                    break;
-                }
-            }
-        }
-        NSAssert(foundMatchingPubkey, @"At least one signature must work.");
-    }
-    BN_clear_free(r);
-    BN_clear_free(s);
-    BN_ULONG base = 0x1b; // pre-EIP155
-    if (chainId) {
-        BIGNUM *v = BN_new(); BN_bin2bn(chainId.bytes, chainId.length, v);
-        // TODO support longer chainIDs
-        base = BN_get_word(v) * 2 + 35;
-        BN_clear_free(v);
-    }
-
-    NSDictionary *signatureDictionary = @{ @"v": @(base + rec),
-            @"r": [rData base64EncodedStringWithOptions:0],
-            @"s":[sData base64EncodedStringWithOptions:0]};
-    return signatureDictionary;
-}
-
-+ (NSData*) simpleSignature:(BTCKey*)keypair forHash:(NSData*)hash {
-    NSDictionary *sig = [self genericSignature: keypair forHash: hash enforceLowS: NO];
-    NSData *rData = (NSData *)sig[@"r"];
-    NSData *sData = (NSData *)sig[@"s"];
-    ///////
-    NSMutableData *sigData = [NSMutableData dataWithLength:64];
-    unsigned char* sigBytes = sigData.mutableBytes;
-    memset(sigBytes, 0, 64);
-
-    memcpy(sigBytes, rData.bytes, 32);
-    memcpy(sigBytes+32, sData.bytes, 32);
-    return sigData;
-}
-
-static int BTCRegenerateKey(EC_KEY *eckey, BIGNUM *priv_key) {
-  BN_CTX *ctx = NULL;
-  EC_POINT *pub_key = NULL;
-  
-  if (!eckey) return 0;
-  
-  const EC_GROUP *group = EC_KEY_get0_group(eckey);
-  
-  BOOL success = NO;
-  if ((ctx = BN_CTX_new())) {
-    if ((pub_key = EC_POINT_new(group))) {
-      if (EC_POINT_mul(group, pub_key, priv_key, NULL, NULL, ctx)) {
-        EC_KEY_set_private_key(eckey, priv_key);
-        EC_KEY_set_public_key(eckey, pub_key);
-        success = YES;
-      }
-    }
-  }
-  
-  if (pub_key) EC_POINT_free(pub_key);
-  if (ctx) BN_CTX_free(ctx);
-  
-  return success;
-}
-
-// Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
-// recid selects which key is recovered
-// if check is non-zero, additional checks are performed
-static int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, BIGNUM *r, BIGNUM *s, const unsigned char *msg, int msglen, int recid, int check) {
-    if (!eckey) return 0;
-
-    int ret = 0;
-    BN_CTX *ctx = NULL;
-
-    BIGNUM *x = NULL;
-    BIGNUM *e = NULL;
-    BIGNUM *order = NULL;
-    BIGNUM *sor = NULL;
-    BIGNUM *eor = NULL;
-    BIGNUM *field = NULL;
-    EC_POINT *R = NULL;
-    EC_POINT *O = NULL;
-    EC_POINT *Q = NULL;
-    BIGNUM *rr = NULL;
-    BIGNUM *zero = NULL;
-    int n = 0;
-    int i = recid / 2;
-
-    const EC_GROUP *group = EC_KEY_get0_group(eckey);
-    if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
-    BN_CTX_start(ctx);
-    order = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_order(group, order, ctx)) { ret = -2; goto err; }
-    x = BN_CTX_get(ctx);
-    if (!BN_copy(x, order)) { ret=-1; goto err; }
-    if (!BN_mul_word(x, i)) { ret=-1; goto err; }
-    if (!BN_add(x, x, r)) { ret=-1; goto err; }
-    field = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
-    if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
-    if ((R = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    if (!EC_POINT_set_compressed_coordinates_GFp(group, R, x, recid % 2, ctx)) { ret=0; goto err; }
-    if (check) {
-        if ((O = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-        if (!EC_POINT_mul(group, O, NULL, R, order, ctx)) { ret=-2; goto err; }
-        if (!EC_POINT_is_at_infinity(group, O)) { ret = 0; goto err; }
-    }
-    if ((Q = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    n = EC_GROUP_get_degree(group);
-    e = BN_CTX_get(ctx);
-    if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
-    if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
-    zero = BN_CTX_get(ctx);
-    if (!BN_zero(zero)) { ret=-1; goto err; }
-    if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
-    rr = BN_CTX_get(ctx);
-    if (!BN_mod_inverse(rr, r, order, ctx)) { ret=-1; goto err; }
-    sor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(sor, s, rr, order, ctx)) { ret=-1; goto err; }
-    eor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
-    if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
-    if (!EC_KEY_set_public_key(eckey, Q)) { ret=-2; goto err; }
-
-    ret = 1;
-
-    err:
-    if (ctx) {
-        BN_CTX_end(ctx);
-        BN_CTX_free(ctx);
-    }
-    if (R != NULL) EC_POINT_free(R);
-    if (O != NULL) EC_POINT_free(O);
-    if (Q != NULL) EC_POINT_free(Q);
-    return ret;
 }
 
 #pragma mark - Utils

--- a/UPTEthereumSignerTests/EthereumSignerTest.m
+++ b/UPTEthereumSignerTests/EthereumSignerTest.m
@@ -1,0 +1,35 @@
+//
+//  EthereumSignerTest.m
+//  UPTEthereumSignerTests
+//
+//  Created by William Morriss on 7/25/18.
+//  Copyright © 2018 ConsenSys. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "EthereumSigner.h"
+#import "CoreBitcoin/BTCData.h"
+
+
+@interface EthereumSignerTest : XCTestCase
+
+@end
+
+@implementation EthereumSignerTest
+
+- (void)testEIP155Example {
+    // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
+    NSData *privateKey = BTCDataFromHex(@"0x4646464646464646464646464646464646464646464646464646464646464646");
+    BTCKey *key = [[BTCKey alloc]
+        initWithPrivateKey:privateKey
+    ];
+    NSData *hash = BTCDataFromHex(@"0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53");
+    NSData *chainId = BTCDataFromHex(@"0x01");
+    NSDictionary *sig = ethereumSignature(key, hash, chainId);
+    XCTAssertEqualObjects(sig[@"v"], @(37));
+    XCTAssertEqualObjects(sig[@"r"], [BTCDataFromHex(@"28EF61340BD939BC2195FE537567866003E1A15D3C71FF63E1590620AA636276") base64EncodedStringWithOptions:0]);
+    XCTAssertEqualObjects(sig[@"s"], [BTCDataFromHex(@"67CBE9D8997F761AECB703304B3800CCF555C9F3DC64214B297FB1966A3B6D83") base64EncodedStringWithOptions:0]);
+}
+
+@end


### PR DESCRIPTION
Closes https://github.com/uport-project/UPTEthereumSigner/issues/20

#### Changes
This adds support for [EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which provides replay protection for ethereum signatures.
The old signatures are now deprecated and clients should switch to the non-deprecated method which provides chainId.
They must also switch to the 9-part transaction payload instead of the 6-part transaction payload when they are providing chainId.
Clients continuing to use the deprecated method will still get valid signatures but those signatures will be valid on every ethereum network.

This also relocates the signature code to a common location and frees the allocated BN's, which I believe were previously leaked.

Reviewers @joshuabell 