### PR TITLE
Reduce Offset Limit To 2

### DIFF
--- a/UPTEthereumSigner/Classes/EthereumSigner.m
+++ b/UPTEthereumSigner/Classes/EthereumSigner.m
@@ -126,7 +126,7 @@ NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId) 
     if (nBitsR <= 256 && nBitsS <= 256) {
         NSData* pubkey = [keypair compressedPublicKey];
         BOOL foundMatchingPubkey = NO;
-        for (int i=0; i < 4; i++) {
+        for (int i=0; i < 2; i++) {
             EC_KEY* key2 = EC_KEY_new_by_curve_name(NID_secp256k1);
             if (ECDSA_SIG_recover_key_GFp(key2, r, s, hashbytes, hashlength, i, 1) == 1) {
                 NSData* pubkey2 = compressedPublicKey(key2);

--- a/UPTEthereumSigner/Classes/EthereumSigner.m
+++ b/UPTEthereumSigner/Classes/EthereumSigner.m
@@ -126,7 +126,7 @@ NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId) 
     if (nBitsR <= 256 && nBitsS <= 256) {
         NSData* pubkey = [keypair compressedPublicKey];
         BOOL foundMatchingPubkey = NO;
-        for (int i=0; i < 2; i++) {
+        for (int i = 0; i < 2; i++) {
             EC_KEY* key2 = EC_KEY_new_by_curve_name(NID_secp256k1);
             if (ECDSA_SIG_recover_key_GFp(key2, r, s, hashbytes, hashlength, i, 1) == 1) {
                 NSData* pubkey2 = compressedPublicKey(key2);

--- a/UPTEthereumSignerTests/EthereumSignerTest.m
+++ b/UPTEthereumSignerTests/EthereumSignerTest.m
@@ -32,4 +32,32 @@
     XCTAssertEqualObjects(sig[@"s"], [BTCDataFromHex(@"67CBE9D8997F761AECB703304B3800CCF555C9F3DC64214B297FB1966A3B6D83") base64EncodedStringWithOptions:0]);
 }
 
+- (void)testDifficultSigs {
+    NSData *privateKey = BTCDataFromHex(@"0x4646464646464646464646464646464646464646464646464646464646464646");
+    BTCKey *key = [[BTCKey alloc]
+        initWithPrivateKey:privateKey
+    ];
+    NSData *chainId = BTCDataFromHex(@"0x01");
+    NSMutableArray *all = [NSMutableArray array];
+    // these are all values in the range [0x00000000, 0x00000C80) that fail to sign with this private key
+    NSArray *values = @[
+        @(315), @(537), @(543), @(550), @(577), @(642), @(662), @(998), @(1020), @(1241),
+        @(1352), @(1496), @(1541), @(1608), @(1742), @(1760), @(2285), @(2295), @(2304),
+        @(2341), @(2665), @(2817), @(2867), @(2915), @(2927), @(3011), @(3064), @(3101)
+    ];
+    NSMutableData *hash = [NSMutableData dataWithLength:sizeof(uint64_t)];
+    for (uint64_t val = 0; val < 0xc80; val++) {
+        *((uint64_t *)(hash.mutableBytes)) = val;
+        @try {
+            NSDictionary *sig = ethereumSignature(key, hash, chainId);
+            XCTAssertNotNil(sig[@"r"]);
+            XCTAssertNotNil(sig[@"s"]);
+        } @catch (NSException *exception) {
+            [all addObject:@(val)];
+        }
+    }
+    // the set of values that fail should diminish over time, and never regress
+    XCTAssertEqualObjects(all, values);
+}
+
 @end


### PR DESCRIPTION
#### Changes
Experimentally, EthereumSigner asserts almost 1% of the time (0.00875).
I contend that there exist no signature with offset out of the range [0, 1].
My hunch is based on EIP155, which suggests that specifying `v = CHAIN_ID * 2 + 35 + offset` would not be ambiguous.
Further, I found evidence this was the case: the failure set for [0x00000000, 0x00000c80) does not change when limiting the offset to [0, 1].
This suggests that the additional range does not help, so I am removing it.
I am also adding a test case that contains the failure set, so we can try to diminish it over time.
Reviewers @joshuabell