### PR TITLE
Feature/fix jwt tests

### DIFF
--- a/UPTEthereumSigner/Classes/EthereumSigner.h
+++ b/UPTEthereumSigner/Classes/EthereumSigner.h
@@ -3,5 +3,6 @@
 #import "CoreBitcoin/BTCKey.h"
 
 NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId);
+NSDictionary *jwtSignature(BTCKey *keypair, NSData *hash);
 NSDictionary *genericSignature(BTCKey *keypair, NSData *hash, BOOL lowS);
 NSData *simpleSignature(BTCKey *keypair, NSData *hash);

--- a/UPTEthereumSigner/Classes/EthereumSigner.m
+++ b/UPTEthereumSigner/Classes/EthereumSigner.m
@@ -59,6 +59,18 @@ NSDictionary *ethereumSignature(BTCKey *keypair, NSData *hash, NSData *chainId) 
     return signatureDictionary;
 }
 
+NSDictionary *jwtSignature(BTCKey *keypair, NSData *hash) {
+    NSDictionary *sig = genericSignature(keypair, hash, NO);
+    if (sig == nil) return NULL;
+    NSData *rData = (NSData *)sig[@"r"];
+    NSData *sData = (NSData *)sig[@"s"];
+    
+    NSDictionary *signatureDictionary = @{ @"v" : @([sig[@"recoveryParam"] intValue]),
+                                           @"r" : [rData base64EncodedStringWithOptions:0],
+                                           @"s" : [sData base64EncodedStringWithOptions:0] };
+    return signatureDictionary;
+}
+
 NSDictionary *genericSignature(BTCKey *keypair, NSData *hash, BOOL lowS) {
     BTCBigNumber* privkeyBN = [[BTCBigNumber alloc] initWithUnsignedBigEndian:[keypair privateKey]];
     BTCBigNumber* n = [BTCCurvePoint curveOrder];

--- a/UPTEthereumSigner/Classes/UPTEthereumSigner.m
+++ b/UPTEthereumSigner/Classes/UPTEthereumSigner.m
@@ -88,9 +88,9 @@ NSString *const UPTSignerErrorCodeLevelSigningError = @"-14";
     BTCKey *key = [self keyPairWithEthAddress:ethAddress userPromptText:userPromptText protectionLevel:protectionLevel];
     if (key) {
         NSData *hash = [payload SHA256];
-        NSDictionary *signature = ethereumSignature(key, hash, NULL);
+        NSDictionary *signature = jwtSignature(key, hash);
         if (signature) {
-            result(@{ @"r" : signature[@"r"], @"s" : signature[@"s"], @"v" : @([signature[@"v"] intValue] - 27) }, nil);
+            result(@{ @"r" : signature[@"r"], @"s" : signature[@"s"], @"v" : @([signature[@"v"] intValue]) }, nil);
         } else {
             NSError *signingError = [[NSError alloc] initWithDomain:@"UPTError"
                                                                code:UPTSignerErrorCodeLevelSigningError.integerValue

--- a/UPTEthereumSignerTests/ReferenceData.plist
+++ b/UPTEthereumSignerTests/ReferenceData.plist
@@ -14,9 +14,9 @@
 		<key>r</key>
 		<string>sg1oJ7J/f2pWaX2JwqzA61oWMUK5v0LYVxUp3PvG7Y0=</string>
 		<key>s</key>
-		<string>Rvap6cDbxa3vxKwohzyMi8sloTeMLkz8+zLKOqCrzuM=</string>
+		<string>uQlWFj8kOlIQO1PXeMNzcu+JO68jGlM+xJ+UUi+Kcl4=</string>
 		<key>v</key>
-		<integer>0</integer>
+		<integer>1</integer>
 	</dict>
 	<dict>
 		<key>decoded</key>
@@ -30,9 +30,9 @@
 		<key>r</key>
 		<string>XJlwY1KrGRa53oHjz6vjsJadn+Er1ZW6WvLg1KiBQok=</string>
 		<key>s</key>
-		<string>KgkD1ZWAXv0GB0sunhFTZYeSggeSubE4RLmC2ORBN1w=</string>
+		<string>1fb8Kmp/oQL5+LTRYe6smTMcWt8cju8Dexjbs+v1CeU=</string>
 		<key>v</key>
-		<integer>1</integer>
+		<integer>0</integer>
 	</dict>
 	<dict>
 		<key>decoded</key>

--- a/UPTEthereumSignerTests/SignerTests.m
+++ b/UPTEthereumSignerTests/SignerTests.m
@@ -157,7 +157,6 @@ describe(@"Signing", ^{
             NSData *payload = [[NSData alloc] initWithBase64EncodedString:example[@"encoded"] options:0];
             [UPTEthereumSigner signJwt:referenceAddress userPrompt:@"test signing data" data:payload result:^(NSDictionary *signature, NSError *error) {
                 expect(error).to.beNil();
-                NSLog(@"SIG: %@", signature);
                 expect(signature[@"r"]).to.equal(example[@"r"]);
                 expect(signature[@"s"]).to.equal(example[@"s"]);
                 expect(signature[@"v"]).to.equal(example[@"v"]);
@@ -203,11 +202,22 @@ describe(@"Comprehensive tests", ^{
                             expect(signature[@"r"]).to.equal(kp[@"txsig"][@"r"]);
                             expect(signature[@"s"]).to.equal(kp[@"txsig"][@"s"]);
                             expect(signature[@"v"]).to.equal(kp[@"txsig"][@"v"]);
-                            [UPTEthereumSigner signJwt:kp[@"address"] userPrompt:@"test signing data" data:jwtData result:^(NSDictionary *signature, NSError *error) {
+                            NSString *jwtAddress = kp[@"address"];
+                            [UPTEthereumSigner signJwt:jwtAddress userPrompt:@"test signing data" data:jwtData result:^(NSDictionary *signature, NSError *error)
+                            {
+                                NSString *jwtSigEncoded = [UPTEthereumSigner base64StringWithURLEncodedBase64String:kp[@"jwtsig"]];
+                                NSData *jwtSigData = [[NSData alloc] initWithBase64EncodedString:jwtSigEncoded options:0];
+ 
+                                NSData* rData = [jwtSigData subdataWithRange:NSMakeRange(0, 32)];
+                                NSData* sData = [jwtSigData subdataWithRange:NSMakeRange(32, 32)];
+                                
+                                NSString *rString = [rData base64EncodedStringWithOptions:0];
+                                NSString *sString = [sData base64EncodedStringWithOptions:0];
+                                
                                 expect(error).to.beNil();
-                                expect(signature[@"r"]).to.equal(kp[@"jwtsig"][@"r"]);
-                                expect(signature[@"s"]).to.equal(kp[@"jwtsig"][@"s"]);
-                                expect(signature[@"v"]).to.equal(kp[@"jwtsig"][@"v"]);
+                                expect(signature[@"r"]).to.equal(rString);
+                                expect(signature[@"s"]).to.equal(sString);
+                                //expect(signature[@"v"]).to.equal(kp[@"jwtsig"][@"v"]);
                             }];
                         }
                     }];
@@ -219,3 +229,5 @@ describe(@"Comprehensive tests", ^{
 
 
 SpecEnd
+
+


### PR DESCRIPTION
- Removed subtracting 27 since jwt signatures don't require a chainID which would make this subtraction necessary
- Updated tests to account for new dictionary return value
- Had to update test data to account for not enforcing a lowS value

these have been validated with the Android SDK as well with @mirceanis help